### PR TITLE
 Added inline attachment functionality 

### DIFF
--- a/src/SimpleEmailServiceMessage.php
+++ b/src/SimpleEmailServiceMessage.php
@@ -2,6 +2,7 @@
 /**
 * SimpleEmailServiceMessage PHP class
 *
+* @link https://github.com/daniel-zahariev/php-aws-ses
 * @version 0.8.3
 * @package AmazonSimpleEmailService
 */

--- a/src/SimpleEmailServiceMessage.php
+++ b/src/SimpleEmailServiceMessage.php
@@ -221,7 +221,7 @@ final class SimpleEmailServiceMessage {
 	public function getRawMessage()
 	{
 		$boundary = uniqid(rand(), true);
-		$raw_message = join("\n", $this->customHeaders) . "\n";
+		$raw_message = (count($this->customHeaders) > 0 ? join("\n", $this->customHeaders) . "\n" : '');
 		// $raw_message .= 'List-Unsubscribe: <mailto:unsubscribe-espc-tech-12345N@aeimedia.co.uk>, <http://aeimedia.co.uk/member/unsubscribe/?listname=espc-tech@aeimedia.co.uk?id=12345N>' . "\n";
 		$raw_message .= 'To: ' . $this->encodeRecipients($this->to) . "\n";
 		$raw_message .= 'From: ' . $this->encodeRecipients($this->from) . "\n";


### PR DESCRIPTION
Now inline images can be added like this:

$rawEmail->addAttachmentFromFile('logo.png','../logo.png','application/octet-stream', '&lt;logo.png&gt;' , 'inline');

and in the html version of the e-mail: <img src='cid:logo.png' />