### PR TITLE
Remove To requirement, do not add empty To header to raw message

### DIFF
--- a/src/SimpleEmailServiceMessage.php
+++ b/src/SimpleEmailServiceMessage.php
@@ -266,7 +266,7 @@ final class SimpleEmailServiceMessage {
 	 * @param string $mimeType  Specify custom MIME type
 	 * @param string $contentId Content ID of the attachment for inclusion in the mail message
 	 * @param string $attachmentType    Attachment type: attachment or inline
-	 * @return  boolean Status of the operation
+	 * @return boolean Status of the operation
 	 */
 	public function addAttachmentFromFile($name, $path, $mimeType = 'application/octet-stream', $contentId = null, $attachmentType = 'attachment') {
 		if (file_exists($path) && is_file($path) && is_readable($path)) {
@@ -284,7 +284,7 @@ final class SimpleEmailServiceMessage {
 	 * @param string $mimeType  Specify custom MIME type
 	 * @param string $contentId Content ID of the attachment for inclusion in the mail message
 	 * @param string $attachmentType    Attachment type: attachment or inline
-	 * @return  boolean Status of the operation
+	 * @return boolean Status of the operation
 	 */
 	public function addAttachmentFromUrl($name, $url, $mimeType = 'application/octet-stream', $contentId = null, $attachmentType = 'attachment') {
 		$data = file_get_contents($url);
@@ -318,8 +318,8 @@ final class SimpleEmailServiceMessage {
 	public function getRawMessage()
 	{
 		$boundary = uniqid(rand(), true);
-		$raw_message = (count($this->customHeaders) > 0 ? join("\n", $this->customHeaders) . "\n" : '');
-		$raw_message .= 'To:' . $this->encodeRecipients($this->to) . "\n";
+		$raw_message = count($this->customHeaders) > 0 ? join("\n", $this->customHeaders) . "\n" : '';
+		$raw_message .= count($this->to) > 0 ? 'To:' . $this->encodeRecipients($this->to) . "\n" : '';
 		$raw_message .= 'From:' . $this->encodeRecipients($this->from) . "\n";
 		if(!empty($this->replyto)) $raw_message .= 'Reply-To:' . $this->encodeRecipients($this->replyto) . "\n";
 
@@ -373,7 +373,7 @@ final class SimpleEmailServiceMessage {
 	/**
 	 * Encode recipient with the specified charset in `recipientsCharset`
 	 *
-	 * @return string            Encoded recipients joined with comma
+	 * @return string Encoded recipients joined with comma
 	 */
 	public function encodeRecipients($recipient)
 	{
@@ -390,6 +390,7 @@ final class SimpleEmailServiceMessage {
 
 	/**
 	* Validates whether the message object has sufficient information to submit a request to SES.
+	*
 	* This does not guarantee the message will arrive, nor that the request will succeed;
 	* instead, it makes sure that no required fields are missing.
 	*
@@ -401,16 +402,16 @@ final class SimpleEmailServiceMessage {
 	* @return boolean
 	*/
 	public function validate() {
-		// at least one To: destination is required
-		if(count($this->to) == 0)
+		// at least one destination is required
+		if (count($this->to) == 0 && count($this->cc) == 0 && count($this->bcc) == 0)
 			return false;
 
 		// sender is required
-		if($this->from == null || strlen($this->from) == 0)
+		if ($this->from == null || strlen($this->from) == 0)
 			return false;
 
 		// subject is required
-		if(($this->subject == null || strlen($this->subject) == 0)) return false;
+		if (($this->subject == null || strlen($this->subject) == 0)) return false;
 
 		// message is required
 		if ((empty($this->messagetext) || strlen((string)$this->messagetext) == 0)

--- a/src/SimpleEmailServiceRequest.php
+++ b/src/SimpleEmailServiceRequest.php
@@ -22,7 +22,7 @@ final class SimpleEmailServiceRequest
 	/**
 	* Constructor
 	*
-	* @param string $ses The SimpleEmailService object making this request
+	* @param SimpleEmailService $ses The SimpleEmailService object making this request
 	* @param string $verb HTTP verb
 	* @return void
 	*/
@@ -244,7 +244,7 @@ final class SimpleEmailServiceRequest
 	/**
 	* Generate the auth string using Hmac-SHA256
 	*
-	* @internal Used by SimpleDBRequest::getResponse()
+	* @internal Used by SimpleEmailServiceRequest::getResponse()
 	* @param string $string String to sign
 	* @return string
 	*/


### PR DESCRIPTION
I came across an issue similar to #8 by trying to send a Bcc-only email with attachment (hence with the `SendRawEmail` API method).

There're two aspects to this:
- your validation would not let emails pass without a `To` header. That can be fixed by looking for at least one destination address, instead of "at least one To destination"
- SES, while accepts raw emails without the `To` header, it does not accept an empty `To` header and returns an error. In the mentioned use case, the `To` header must be completely omitted.
