### PR TITLE
Support for additional regions

### DIFF
--- a/src/SimpleEmailService.php
+++ b/src/SimpleEmailService.php
@@ -51,10 +51,26 @@
 class SimpleEmailService
 {
 	/**
-	 * @link(AWS SES regions, http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html)
+	 * @link(AWS SES regions, https://docs.aws.amazon.com/general/latest/gr/ses.html)
 	 */
+	const AWS_CA_CENTRAL_1 = 'email.ca-central-1.amazonaws.com';
+	const AWS_AP_NORTHEAST_1 = 'email.ap-northeast-1.amazonaws.com';
+	const AWS_AP_NORTHEAST_2 = 'email.ap-northeast-2.amazonaws.com';
+	const AWS_AP_SOUTH_1 = 'email.ap-south-1.amazonaws.com';
+	const AWS_AP_SOUTHEAST_1 = 'email.ap-southeast-1.amazonaws.com';
+	const AWS_AP_SOUTHEAST_2 = 'email.ap-southeast-2.amazonaws.com';
+	const AWS_EU_CENTRAL_1 = 'email.eu-central-1.amazonaws.com';
+	const AWS_EU_WEST_1 = 'email.eu-west-1.amazonaws.com';
+	const AWS_EU_WEST_2 = 'email.eu-west-2.amazonaws.com';
+	const AWS_SA_EAST_1 = 'email.sa-east-1.amazonaws.com';
 	const AWS_US_EAST_1 = 'email.us-east-1.amazonaws.com';
+	const AWS_US_EAST_2 = 'email.us-east-2.amazonaws.com';
+	const AWS_US_GOV_WEST_1 = 'email.us-gov-west-1.amazonaws.com';
 	const AWS_US_WEST_2 = 'email.us-west-2.amazonaws.com';
+	
+	/**
+	 * Deprecated, available for backward compatibility
+	 */
 	const AWS_EU_WEST1 = 'email.eu-west-1.amazonaws.com';
 
 	const REQUEST_SIGNATURE_V3 = 'v3';


### PR DESCRIPTION
Support for 11 additional regions.

Deprecation of AWS_EU_WEST1 as AWS_EU_WEST_1 (with underscore) is more consistent with the naming of the other constants and naming by AWS. This takes care of #57. The old constant is still available for backwards compatibility.

Update of the URL where currently the SES regions are published. 