### PR TITLE
Only encode subject and recipients when necessary

### DIFF
--- a/src/SimpleEmailServiceMessage.php
+++ b/src/SimpleEmailServiceMessage.php
@@ -533,7 +533,11 @@ final class SimpleEmailServiceMessage {
         }
 
         if ($this->subject != null && strlen($this->subject) > 0) {
-            $raw_message .= 'Subject: =?' . $this->subjectCharset . '?B?' . base64_encode($this->subject) . "?=\n";
+            if (preg_match('/[^\x20-\x7f]/', $this->subject)) {
+                $raw_message .= 'Subject: =?' . $this->subjectCharset . '?B?' . base64_encode($this->subject) . "?=\n";
+            } else {
+                $raw_message .= 'Subject: ' . $this->subject . "\n";
+            }
         }
 
         $raw_message .= 'MIME-Version: 1.0' . "\n";
@@ -589,7 +593,9 @@ final class SimpleEmailServiceMessage {
         }
 
         if (preg_match("/(.*)<(.*)>/", $recipient, $regs)) {
-            $recipient = '=?' . $this->recipientsCharset . '?B?' . base64_encode($regs[1]) . '?= <' . $regs[2] . '>';
+            if (preg_match('/[^\x20-\x7f]/', $regs[1])) {
+                $recipient = '=?' . $this->recipientsCharset . '?B?' . base64_encode($regs[1]) . '?= <' . $regs[2] . '>';
+            }
         }
 
         return $recipient;


### PR DESCRIPTION
Spamassassin marks you down one point for unnecessarily encoding headers. When spam filters are set low, emails sent through this class will be higher rated as spam.

The rule is: 1.05 FROM_EXCESS_BASE64_2   META: From: base64 encoded unnecessarily